### PR TITLE
Bump html-minifier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "html-minifier": "~0.5.0",
+    "html-minifier": "~0.5.4",
     "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`v0.5.4` fixes several bugs
