### PR TITLE
Use chalk module to colorize terminal output

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "html-minifier": "~0.5.0",
-    "grunt-lib-contrib": "~0.6.1"
+    "grunt-lib-contrib": "~0.6.1",
+    "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-internal": "~0.4.4",

--- a/tasks/htmlmin.js
+++ b/tasks/htmlmin.js
@@ -11,6 +11,7 @@
 module.exports = function (grunt) {
   var minify = require('html-minifier').minify;
   var helper = require('grunt-lib-contrib').init(grunt);
+  var chalk = require('chalk');
 
   grunt.registerMultiTask('htmlmin', 'Minify HTML', function () {
     var options = this.options();
@@ -40,7 +41,7 @@ module.exports = function (grunt) {
         grunt.log.warn('Destination not written because minified HTML was empty.');
       } else {
         grunt.file.write(file.dest, min);
-        grunt.log.writeln('File ' + file.dest + ' created.');
+        grunt.log.writeln('File ' + chalk.cyan(file.dest) + ' created.');
         helper.minMaxInfo(min, max);
       }
     });


### PR DESCRIPTION
Add [chalk](https://github.com/sindresorhus/chalk) as a dependency and use it to colorize terminal output in consistency with other contrib plugins.
