### PR TITLE
Add homepage, repository and bugs information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,18 @@
   "name": "grunt-contrib-htmlmin",
   "description": "Minify HTML",
   "version": "0.2.0",
+  "homepage": "https://github.com/gruntjs/grunt-contrib-htmlmin",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
   },
-  "repository": "gruntjs/grunt-contrib-htmlmin",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/gruntjs/grunt-contrib-htmlmin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gruntjs/grunt-contrib-htmlmin/issues"
+  },
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
I noticed that the grunt-contrib README list of projects had a [broken/missing link for `grunt-contrib-htmlmin`](https://github.com/gruntjs/grunt-contrib#grunt-contrib-htmlmin-v020--)

I think I've tracked it down to this project lacking the homepage field in the `package.json`. It also was missing a couple other fields that the other grunt-contrib plugins have.

This pull request adds in those missing fields.
