### PR TITLE
Add input file name on error

### DIFF
--- a/tasks/htmlmin.js
+++ b/tasks/htmlmin.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
       var max = grunt.file.read(src);
 
       if (max.length === 0) {
-        return grunt.log.warn('Destination not written because source file was empty.');
+        return grunt.log.warn('Destination ' + chalk.cyan(src) + ' not written because source file was empty.');
       }
 
       try {
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
       }
 
       if (min.length === 0) {
-        return grunt.log.warn('Destination not written because minified HTML was empty.');
+        return grunt.log.warn('Destination ' + chalk.cyan(src) + ' not written because there was nothing to minify.');
       }
 
       grunt.file.write(file.dest, min);


### PR DESCRIPTION
This commit adds the name of the potential output file which is not written
because there are no characters saved and thus the output does not differ from
the input file.

I think providing the input file name is easier to identify than not naming any file at all.
If you have a couple of files (let's say 10 or more) you don't to check manual which file was not written.

Also another improvement could be to just copy over the file instead of doing nothing because this might be needed in a production environment anyway after the build finished - at least we need it in out setup.
A workaround could be to copy all files to one directory and then minify them within the same dir. But this does not seem to be a good way out.

---

For people who search:
minified template not available, present, copied, lost
build fails
"Destination not written because"
