### PR TITLE
Use verbose output and counter

### DIFF
--- a/tasks/htmlmin.js
+++ b/tasks/htmlmin.js
@@ -21,13 +21,13 @@ module.exports = function (grunt) {
       var src = file.src[0];
 
       if (!grunt.file.exists(src || ' ')) {
-        return grunt.log.warn('Source file "' + chalk.cyan(src) + '" not found.');
+        return grunt.verbose.warn('Source file "' + chalk.cyan(src) + '" not found.');
       }
 
       var max = grunt.file.read(src);
 
       if (max.length === 0) {
-        return grunt.log.warn('Destination ' + chalk.cyan(src) + ' not written because source file was empty.');
+        return grunt.verbose.warn('Destination ' + chalk.cyan(src) + ' not written because source file was empty.');
       }
 
       try {
@@ -37,12 +37,12 @@ module.exports = function (grunt) {
       }
 
       if (min.length === 0) {
-        return grunt.log.warn('Destination ' + chalk.cyan(src) + ' not written because there was nothing to minify.');
+        return grunt.verbose.warn('Destination ' + chalk.cyan(src) + ' not written because there was nothing to minify.');
       }
 
 	  count++;
       grunt.file.write(file.dest, min);
-      grunt.log.writeln('Minified ' + chalk.cyan(file.dest) + ' ' + prettyBytes(max.length) + ' → ' + prettyBytes(min.length));
+      grunt.verbose.writeln('Minified ' + chalk.cyan(file.dest) + ' ' + prettyBytes(max.length) + ' → ' + prettyBytes(min.length));
     });
     grunt.log.writeln('Minified ' + chalk.cyan(count) + ' files' + (this.files.length !== count ? ' (' + chalk.red(this.files.length - count) + ' failed)' : '') +'.');
   });


### PR DESCRIPTION
Implements #97 -

Listing every file it processes can be quite a lot of spam, so changing it to use grunt.verbose.writeln instead of grunt.log.writeln would make it nicer to use (keeping the warnings as they are etc). Basically this makes a huge difference on windows where the log size is severely restricted.

Additionally adding a log (not verbose) count after finishing would keep people informed how things went.
