### PR TITLE
Update html-minifier to v3.0.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
+  - "6"
   - "iojs"
 
 matrix:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,5 +42,5 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-internal');
 
   grunt.registerTask('test', ['jshint', 'clean', 'htmlmin', 'nodeunit']);
-  grunt.registerTask('default', ['test', 'build-contrib']);
+  grunt.registerTask('default', ['test', 'contrib-core', 'contrib-ci:skipIfExists']);
 };

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,13 @@ version: "{build}"
 # What combinations to test
 environment:
   matrix:
-    - nodejs_version: "0.10"
-      platform: x86
-    - nodejs_version: "0.12"
-      platform: x86
     - nodejs_version: "4"
       platform: x64
     - nodejs_version: "4"
       platform: x86
     - nodejs_version: "5"
+      platform: x86
+    - nodejs_version: "6"
       platform: x86
 
 install:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "gruntjs/grunt-contrib-htmlmin",
   "license": "MIT",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0"
   },
   "main": "tasks/htmlmin.js",
   "scripts": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "html-minifier": "~2.1.7",
+    "html-minifier": "~3.0.1",
     "pretty-bytes": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Note that html-minifier v3.0.0 doesn't support node.js 0.10 and 0.12 anymore.

/CC @vladikoff: should we make a release before this, with html-minifier 2.1.x and then bump the major version?